### PR TITLE
Fix syntax 'error'

### DIFF
--- a/README.md
+++ b/README.md
@@ -376,7 +376,7 @@ Here is a pseudocode implementation of what `a` might look like:
 function a(done) {
   download('https://pbs.twimg.com/media/B4DDWBrCEAA8u4O.jpg:large', function doneDownloading(error, png) {
     // handle error if there was one
-    if (err) console.log('uh-oh!', error)
+    if (error) console.log('uh-oh!', error)
     
     // call done when you are all done
     done()


### PR DESCRIPTION
Hopefully the additional 2 chars need no further description.

🐈
